### PR TITLE
give access to private frequencies

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -35,6 +35,11 @@ Citizen.CreateThread(function()
                                 TriggerServerEvent("QBCore:ToggleDuty")
                                 TriggerServerEvent("police:server:UpdateBlips")
                                 TriggerEvent('qb-policealerts:ToggleDuty', onDuty)
+                                if onDuty then
+                                    exports["rp-radio"]:GivePlayerAccessToFrequencies(1, 2)
+                                else
+                                    exports["rp-radio"]:RemovePlayerAccessToFrequencies(1, 2)
+                                end
                             end
                         elseif #(pos - vector3(v.x, v.y, v.z)) < 2.5 then
                             DrawText3D(v.x, v.y, v.z, "on/off duty")


### PR DESCRIPTION
this function will add police to private frequency when they are on duty
----
example to add more private frequencies for police job
exports["rp-radio"]:GivePlayerAccessToFrequencies(1, 2, 3, 4)
exports["rp-radio"]:RemovePlayerAccessToFrequencies(1, 2, 3, 4)