### PR TITLE
Different way of using the evidence stashed (police)

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -13,6 +13,27 @@ function DrawText3D(x, y, z, text)
     ClearDrawOrigin()
 end
 
+function Input(Titel, Placeholder, MaxLenght)
+	AddTextEntry('FMMC_KEY_TIP1', Titel)
+	DisplayOnscreenKeyboard(1, "FMMC_KEY_TIP1", "", Placeholder, "", "", "", MaxLenght)
+	blockinput = true
+
+	while UpdateOnscreenKeyboard() ~= 1 and UpdateOnscreenKeyboard() ~= 2 do
+		Citizen.Wait(0)
+	end
+		
+	if UpdateOnscreenKeyboard() ~= 2 then
+		local result = GetOnscreenKeyboardResult()
+		Citizen.Wait(500)
+		blockinput = false
+		return result --Returns the result
+	else
+		Citizen.Wait(500)
+		blockinput = false
+		return nil
+	end
+end
+
 local currentGarage = 1
 Citizen.CreateThread(function()
     while true do
@@ -47,14 +68,17 @@ Citizen.CreateThread(function()
                         if #(pos - vector3(v.x, v.y, v.z)) < 1.0 then
                             DrawText3D(v.x, v.y, v.z, "~g~E~w~ -    Evidence stash")
                             if IsControlJustReleased(0, 38) then
-                                TriggerServerEvent("inventory:server:OpenInventory", "stash", "policeevidence", {
-                                    maxweight = 4000000,
-                                    slots = 500,
-                                })
-                                TriggerEvent("inventory:client:SetCurrentStash", "policeevidence")
+                                local drawer = Input("Which drawer do you want to look at?", "", 2)
+                                if drawer ~= nil then
+                                    TriggerServerEvent("inventory:server:OpenInventory", "stash", " 1 | Drawer "..drawer, {
+                                        maxweight = 4000000,
+                                        slots = 500,
+                                    })
+                                    TriggerEvent("inventory:client:SetCurrentStash", " 1 | Drawer "..drawer)
+                                end
                             end
                         elseif #(pos - vector3(v.x, v.y, v.z)) < 1.5 then
-                            DrawText3D(v.x, v.y, v.z, "evidence stash")
+                            DrawText3D(v.x, v.y, v.z, "Stash 1")
                         end
                     end
                 end
@@ -64,14 +88,17 @@ Citizen.CreateThread(function()
                         if #(pos - vector3(v.x, v.y, v.z)) < 1.0 then
                             DrawText3D(v.x, v.y, v.z, "~g~E~w~ - evidence stash")
                             if IsControlJustReleased(0, 38) then
-                                TriggerServerEvent("inventory:server:OpenInventory", "stash", "policeevidence2", {
-                                    maxweight = 4000000,
-                                    slots = 500,
-                                })
-                                TriggerEvent("inventory:client:SetCurrentStash", "policeevidence2")
+                                local drawer = Input("Which drawer do you want to look at?", "", 2)
+                                if drawer ~= nil then
+                                    TriggerServerEvent("inventory:server:OpenInventory", "stash", " 2 | Drawer "..drawer, {
+                                        maxweight = 4000000,
+                                        slots = 500,
+                                    })
+                                    TriggerEvent("inventory:client:SetCurrentStash", " 2 | Drawer "..drawer)
+                                end
                             end
                         elseif #(pos - vector3(v.x, v.y, v.z)) < 1.5 then
-                            DrawText3D(v.x, v.y, v.z, "evidence stash")
+                            DrawText3D(v.x, v.y, v.z, "Stash 2")
                         end
                     end
                 end
@@ -81,14 +108,17 @@ Citizen.CreateThread(function()
                         if #(pos - vector3(v.x, v.y, v.z)) < 1.0 then
                             DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Evidence stash")
                             if IsControlJustReleased(0, 38) then
-                                TriggerServerEvent("inventory:server:OpenInventory", "stash", "policeevidence3", {
-                                    maxweight = 4000000,
-                                    slots = 500,
-                                })
-                                TriggerEvent("inventory:client:SetCurrentStash", "policeevidence3")
+                                local drawer = Input("Which drawer do you want to look at?", "", 2)
+                                if drawer ~= nil then
+                                    TriggerServerEvent("inventory:server:OpenInventory", "stash", " 3 | Drawer "..drawer, {
+                                        maxweight = 4000000,
+                                        slots = 500,
+                                    })
+                                    TriggerEvent("inventory:client:SetCurrentStash", " 3 | Drawer "..drawer)
+                                end
                             end
                         elseif #(pos - vector3(v.x, v.y, v.z)) < 1.5 then
-                            DrawText3D(v.x, v.y, v.z, "evidence stash")
+                            DrawText3D(v.x, v.y, v.z, "Stash 3")
                         end
                     end
                 end


### PR DESCRIPTION
RP focused, e.g. you can still start from drawer 1 until it is full then go to drawer 2. But I made this for RP specific moments if the police ever need to put the evidence away at a specific place. For court or for high profile gangsters, you can type in the mdt inside of the reports for a specific RP scenario that the evidence is located at the evidence Stash 2 Drawer 12 for example. Also removes the need to put stuff in the strash since you have so much more space to put evidence away.

Using the DisplayOnscreenKeyboard native from fivem. The if drawer ~= nil then is for safety procautions. Since it can happen that it will give you an error that drawer = nil. If y'all want to use it is your decision. Because apparently people Roleplay for the money these days, not the RP KekW.