### PR TITLE
Added Per-Grade Vehicle Support

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -509,8 +509,9 @@ function VehicleList(isDown)
     ped = PlayerPedId();
     MenuTitle = "Vehicles:"
     ClearMenu()
-    for k, v in pairs(Config.Vehicles) do
-        Menu.addButton(Config.Vehicles[k], "TakeOutVehicle", k, "Garage", " Engine: 100%", " Body: 100%", " Fuel: 100%")
+    local authorizedVehicles = Config.AuthorizedVehicles[QBCore.Functions.GetPlayerData().job.grade.level]
+    for k, v in pairs(authorizedVehicles) do
+        Menu.addButton(authorizedVehicles[k], "TakeOutVehicle", k, "Garage", " Engine: 100%", " Body: 100%", " Fuel: 100%")
     end
     if IsArmoryWhitelist() then
         for veh, label in pairs(Config.WhitelistedVehicles) do

--- a/config.lua
+++ b/config.lua
@@ -127,15 +127,63 @@ Config.SecurityCameras = {
     },
 }
 
-Config.Vehicles = {
-    ["police"] = "Police Car 1",
-    ["police2"] = "Police Car 2",
-    ["police3"] = "Police Car 3",
-    ["police4"] = "Police Car 4",
-    ["policeb"] = "Police Car 5",
-    ["policet"] = "Police Car 6",
-    ["sheriff"] = "Sheriff Car 1",
-    ["sheriff2"] = "Sheriff Car 2",
+Config.AuthorizedVehicles = {
+	-- Grade 0
+	[0] = {
+		["police"] = "Police Car 1",
+		["police2"] = "Police Car 2",
+		["police3"] = "Police Car 3",
+		["police4"] = "Police Car 4",
+		["policeb"] = "Police Car 5",
+		["policet"] = "Police Car 6",
+		["sheriff"] = "Sheriff Car 1",
+		["sheriff2"] = "Sheriff Car 2",
+	},
+	-- Grade 1
+	[1] = {
+		["police"] = "Police Car 1",
+		["police2"] = "Police Car 2",
+		["police3"] = "Police Car 3",
+		["police4"] = "Police Car 4",
+		["policeb"] = "Police Car 5",
+		["policet"] = "Police Car 6",
+		["sheriff"] = "Sheriff Car 1",
+		["sheriff2"] = "Sheriff Car 2",
+
+	},
+	-- Grade 2
+	[2] = {
+		["police"] = "Police Car 1",
+		["police2"] = "Police Car 2",
+		["police3"] = "Police Car 3",
+		["police4"] = "Police Car 4",
+		["policeb"] = "Police Car 5",
+		["policet"] = "Police Car 6",
+		["sheriff"] = "Sheriff Car 1",
+		["sheriff2"] = "Sheriff Car 2",
+	},
+	-- Grade 3
+	[3] = {
+		["police"] = "Police Car 1",
+		["police2"] = "Police Car 2",
+		["police3"] = "Police Car 3",
+		["police4"] = "Police Car 4",
+		["policeb"] = "Police Car 5",
+		["policet"] = "Police Car 6",
+		["sheriff"] = "Sheriff Car 1",
+		["sheriff2"] = "Sheriff Car 2",
+	},
+	-- Grade 4
+	[4] = {
+		["police"] = "Police Car 1",
+		["police2"] = "Police Car 2",
+		["police3"] = "Police Car 3",
+		["police4"] = "Police Car 4",
+		["policeb"] = "Police Car 5",
+		["policet"] = "Police Car 6",
+		["sheriff"] = "Sheriff Car 1",
+		["sheriff2"] = "Sheriff Car 2",
+	}
 }
 
 Config.WhitelistedVehicles = {}


### PR DESCRIPTION
Added ability to specify cars that are authorized, similar to the ESX counterpart.  Additionally, grades are referenced by grade number, instead of grade name (may have marginal storage benefits)