### PR TITLE
Set police livery for POLMAV

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -206,6 +206,8 @@ Citizen.CreateThread(function()
                                     else
                                         local coords = Config.Locations["helicopter"][k]
                                         QBCore.Functions.SpawnVehicle(Config.Helicopter, function(veh)
+				            SetVehicleLivery(veh , 0)
+					    SetVehicleMod(veh, 0, 48)
                                             SetVehicleNumberPlateText(veh, "ZULU"..tostring(math.random(1000, 9999)))
                                             SetEntityHeading(veh, coords.w)
                                             exports['LegacyFuel']:SetFuel(veh, 100.0)


### PR DESCRIPTION
POLMAV spawns with Police or Ambulance livery, this will force Police livery only for this job garage. Big thanks to BerkieB on QB-Core discord for the assistance in sorting thing. (Apologies if theres odd spacing in this, for some reason I can't get the lines to break down correctly)