### PR TITLE
:bug: Missing SetDuty Net Event for Toggling onDuty

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -138,6 +138,11 @@ RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
     end
 end)
 
+RegisterNetEvent('QBCore:Client:SetDuty', function(duty)
+    onDuty = duty
+    TriggerServerEvent('police:server:UpdateCurrentCops')
+end)
+
 RegisterNetEvent('police:client:sendBillingMail', function(amount)
     SetTimeout(math.random(2500, 4000), function()
         local gender = "Mr."


### PR DESCRIPTION
**Describe Pull request**
When toggling duty on/off, it creates a weird cycle where you are believed to be on/off duty as indicated by the duty check, but the police job resource doesn't see that update. You can't access protected frequencies, vehicle spawns, the armory, etc, without going back to the duty blip multiple times.  On duty status now matches what is reported via `/job` command.

The ToggleDuty event in qb-core calls back to the SetDuty event in the client, and this does not exist in qb-policejob.
https://github.com/qbcore-framework/qb-core/blob/34c574daf295ff1c3f1ebe4447d51a2a82b9ebdc/server/events.lua#L152

I added it along with the check to update the cop count, similar to qb-ambulancejob. 

Fixes #121

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Tested functionality related to the police job toggle and important features (vehicle spawn, access protected frequencies, armory)
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
