### PR TITLE
'Police Vehicles' garage header fix

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -190,7 +190,7 @@ function MenuGarage()
     local vehicleMenu = {
         {
             header = "Police Vehicles",
-            txt = ""
+            isMenuHeader = true
         }
     }
 


### PR DESCRIPTION
**Describe Pull request**
Fixes the police vehicles garage header _if it wasn't meant to be this way._

**If your PR is to fix an issue mention that issue here**

You can click/access the garage header as it is right now.
Based on the fact that all the other garages have unclickable / unaccessible headers, it should be like this.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality?  Yes
- Does your code fit the style guidelines?  Yes
- Does your PR fit the contribution guidelines? Yes