### PR TITLE
Menu patch 01

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -238,8 +238,8 @@ function MenuImpound(currentSelection)
         else
             shouldContinue = true
             for _ , v in pairs(result) do
-                local enginePercent = QBCore.Round(v.engine / 10, 0)
-                local bodyPercent = QBCore.Round(v.body / 10, 0)
+                local enginePercent = QBCore.Shared.Round(v.engine / 10, 0)
+                local bodyPercent = QBCore.Shared.Round(v.body / 10, 0)
                 local currentFuel = v.fuel
                 local vname = QBCore.Shared.Vehicles[v.vehicle].name
 

--- a/client/job.lua
+++ b/client/job.lua
@@ -1,5 +1,5 @@
 -- Variables
-local currentGarage = 1
+local currentGarage = 0
 local inFingerprint = false
 local FingerPrintSessionId = nil
 
@@ -122,46 +122,40 @@ end
 
 function TakeOutImpound(vehicle)
     local coords = Config.Locations["impound"][currentGarage]
-    QBCore.Functions.SpawnVehicle(vehicle.vehicle, function(veh)
-        QBCore.Functions.TriggerCallback('qb-garage:server:GetVehicleProperties', function(properties)
-            QBCore.Functions.SetVehicleProperties(veh, properties)
-            SetVehicleNumberPlateText(veh, vehicle.plate)
-            SetEntityHeading(veh, coords.w)
-            exports['LegacyFuel']:SetFuel(veh, vehicle.fuel)
-            doCarDamage(veh, vehicle)
-            TriggerServerEvent('police:server:TakeOutImpound',vehicle.plate)
-            closeMenuFull()
-            TaskWarpPedIntoVehicle(PlayerPedId(), veh, -1)
-            TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(veh))
-            SetVehicleEngineOn(veh, true, true)
-        end, vehicle.plate)
-    end, coords, true)
+    if coords then
+        QBCore.Functions.SpawnVehicle(vehicle.vehicle, function(veh)
+            QBCore.Functions.TriggerCallback('qb-garage:server:GetVehicleProperties', function(properties)
+                QBCore.Functions.SetVehicleProperties(veh, properties)
+                SetVehicleNumberPlateText(veh, vehicle.plate)
+                SetEntityHeading(veh, coords.w)
+                exports['LegacyFuel']:SetFuel(veh, vehicle.fuel)
+                doCarDamage(veh, vehicle)
+                TriggerServerEvent('police:server:TakeOutImpound',vehicle.plate)
+                closeMenuFull()
+                TaskWarpPedIntoVehicle(PlayerPedId(), veh, -1)
+                TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(veh))
+                SetVehicleEngineOn(veh, true, true)
+            end, vehicle.plate)
+        end, coords, true)
+    end
 end
-
-RegisterNetEvent('police:client:TakeOutImpound', function(data)
-    local vehicle = data.vehicle
-    TakeOutImpound(vehicle)
-end)
 
 function TakeOutVehicle(vehicleInfo)
     local coords = Config.Locations["vehicle"][currentGarage]
-    QBCore.Functions.SpawnVehicle(vehicleInfo, function(veh)
-	    SetCarItemsInfo()
-        SetVehicleNumberPlateText(veh, "PLZI"..tostring(math.random(1000, 9999)))
-        SetEntityHeading(veh, coords.w)
-        exports['LegacyFuel']:SetFuel(veh, 100.0)
-        closeMenuFull()
-        TaskWarpPedIntoVehicle(PlayerPedId(), veh, -1)
-        TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(veh))
-        TriggerServerEvent("inventory:server:addTrunkItems", QBCore.Functions.GetPlate(veh), Config.CarItems)
-        SetVehicleEngineOn(veh, true, true)
-    end, coords, true)
+    if coords then
+        QBCore.Functions.SpawnVehicle(vehicleInfo, function(veh)
+            SetCarItemsInfo()
+            SetVehicleNumberPlateText(veh, "PLZI"..tostring(math.random(1000, 9999)))
+            SetEntityHeading(veh, coords.w)
+            exports['LegacyFuel']:SetFuel(veh, 100.0)
+            closeMenuFull()
+            TaskWarpPedIntoVehicle(PlayerPedId(), veh, -1)
+            TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(veh))
+            TriggerServerEvent("inventory:server:addTrunkItems", QBCore.Functions.GetPlate(veh), Config.CarItems)
+            SetVehicleEngineOn(veh, true, true)
+        end, coords, true)
+    end
 end
-
-RegisterNetEvent('police:client:TakeOutVehicle', function(data)
-    local vehicle = data.vehicle
-    TakeOutVehicle(vehicle)
-end)
 
 local function IsArmoryWhitelist() -- being removed
     local retval = false
@@ -180,13 +174,7 @@ local function SetWeaponSeries()
     end
 end
 
-function round(num, numDecimalPlaces)
-    return tonumber(string.format("%." .. (numDecimalPlaces or 0) .. "f", num))
-end
-
--- GUI Menu Functions (being replaced)
-
-function MenuGarage()
+function MenuGarage(currentSelection)
     local vehicleMenu = {
         {
             header = "Police Vehicles",
@@ -202,7 +190,8 @@ function MenuGarage()
             params = {
                 event = "police:client:TakeOutVehicle",
                 args = {
-                    vehicle = veh
+                    vehicle = veh,
+                    currentSelection = currentSelection
                 }
             }
         }
@@ -216,7 +205,8 @@ function MenuGarage()
                 params = {
                     event = "police:client:TakeOutVehicle",
                     args = {
-                        vehicle = veh
+                        vehicle = veh,
+                        currentSelection = currentSelection
                     }
                 }
             }
@@ -234,8 +224,7 @@ function MenuGarage()
     exports['qb-menu']:openMenu(vehicleMenu)
 end
 
-
-function MenuImpound()
+function MenuImpound(currentSelection)
     local impoundMenu = {
         {
             header = "Impounded Vehicles",
@@ -249,8 +238,8 @@ function MenuImpound()
         else
             shouldContinue = true
             for _ , v in pairs(result) do
-                local enginePercent = round(v.engine / 10, 0)
-                local bodyPercent = round(v.body / 10, 0)
+                local enginePercent = QBCore.Round(v.engine / 10, 0)
+                local bodyPercent = QBCore.Round(v.body / 10, 0)
                 local currentFuel = v.fuel
                 local vname = QBCore.Shared.Vehicles[v.vehicle].name
 
@@ -260,7 +249,8 @@ function MenuImpound()
                     params = {
                         event = "police:client:TakeOutImpound",
                         args = {
-                            vehicle = v
+                            vehicle = v,
+                            currentSelection = currentSelection
                         }
                     }
                 }
@@ -287,14 +277,24 @@ function closeMenuFull()
     exports['qb-menu']:closeMenu()
 end
 
--- NUI
+--[[
+    Section: NUI Callbacks
+
+    Description:
+    Please place all your nuis under this sections
+--]]
 
 RegisterNUICallback('closeFingerprint', function()
     SetNuiFocus(false, false)
     inFingerprint = false
 end)
 
--- Events
+--[[
+    Section: Events
+
+    Description:
+    Please place all your events under this sections
+--]]
 
 RegisterNetEvent('police:client:showFingerprint', function(playerId)
     openFingerprintUI()
@@ -377,13 +377,62 @@ RegisterNetEvent('police:client:CheckStatus', function()
     end)
 end)
 
---Threads
+RegisterNetEvent("police:client:VehicleMenuHeader", function (data)
+    local ped = PlayerPedId()
+    local pos = GetEntityCoords(ped)
+    local takeDist = Config.Locations['vehicle'][data.currentSelection]
+    takeDist = vector3(takeDist.x, takeDist.y,  takeDist.z)
+    if #(pos - takeDist) <= 1.5 then
+        MenuGarage(data.currentSelection)
+        currentGarage = data.currentSelection
+    end
+end)
 
+
+RegisterNetEvent("police:client:ImpoundMenuHeader", function (data)
+    local pos = GetEntityCoords(PlayerPedId())
+    local takeDist = Config.Locations['impound'][data.currentSelection]
+    takeDist = vector3(takeDist.x, takeDist.y,  takeDist.z)
+    if #(pos - takeDist) <= 1.5 then
+        MenuImpound(data.currentSelection)
+        currentGarage = k
+    end
+end)
+
+RegisterNetEvent('police:client:TakeOutImpound', function(data)
+    local pos = GetEntityCoords(PlayerPedId())
+    local takeDist = Config.Locations['impound'][data.currentSelection]
+    takeDist = vector3(takeDist.x, takeDist.y,  takeDist.z)
+    if #(pos - takeDist) <= 1.5 then
+        local vehicle = data.vehicle
+        TakeOutImpound(vehicle)
+    end
+end)
+
+RegisterNetEvent('police:client:TakeOutVehicle', function(data)
+    local pos = GetEntityCoords(PlayerPedId())
+    local takeDist = Config.Locations['vehicle'][data.currentSelection]
+    takeDist = vector3(takeDist.x, takeDist.y,  takeDist.z)
+    if #(pos - takeDist) <= 1.5 then
+        local vehicle = data.vehicle
+        TakeOutVehicle(vehicle)
+    end
+end)
+
+--[[
+    Section: Threads
+
+    Description:
+    This is where all the threads go.
+--]]
+
+-- Toggle Duty
 CreateThread(function()
     while true do
-        sleep = 2000
+        local sleep = 2000
         if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
             local pos = GetEntityCoords(PlayerPedId())
+
             for k, v in pairs(Config.Locations["duty"]) do
                 if #(pos - v) < 5 then
                     sleep = 5
@@ -404,12 +453,23 @@ CreateThread(function()
                     end
                 end
             end
+        end
+        Wait(sleep)
+    end
+end)
 
+-- Stash 1
+CreateThread(function()
+    Wait(1000)
+    while true do
+        local sleep = 2000
+        if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
+            local pos = GetEntityCoords(PlayerPedId())
             for k, v in pairs(Config.Locations["evidence"]) do
                 if #(pos - v) < 2 then
                     sleep = 5
                     if #(pos - v) < 1.0 then
-                        DrawText3D(v.x, v.y, v.z, "~g~E~w~ -    Evidence stash")
+                        DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Evidence stash")
                         if IsControlJustReleased(0, 38) then
                             local drawer = exports['qb-input']:ShowInput({
                                 header = 'Evidence Stash',
@@ -437,7 +497,18 @@ CreateThread(function()
                     end
                 end
             end
+        end
+        Wait(sleep)
+    end
+end)
 
+-- Stash 2
+CreateThread(function()
+    Wait(1000)
+    while true do
+        local sleep = 2000
+        if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
+            local pos = GetEntityCoords(PlayerPedId())
             for k, v in pairs(Config.Locations["evidence2"]) do
                 if #(pos - v) < 2 then
                     sleep = 5
@@ -470,7 +541,18 @@ CreateThread(function()
                     end
                 end
             end
+        end
+        Wait(sleep)
+    end
+end)
 
+-- Stash 3
+CreateThread(function()
+    Wait(1000)
+    while true do
+        local sleep = 2000
+        if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
+            local pos = GetEntityCoords(PlayerPedId())
             for k, v in pairs(Config.Locations["evidence3"]) do
                 if #(pos - v) < 2 then
                     sleep = 5
@@ -503,12 +585,51 @@ CreateThread(function()
                     end
                 end
             end
+        end
+        Wait(sleep)
+    end
+end)
 
+-- Personal Stash
+CreateThread(function()
+    Wait(1000)
+    while true do
+        local sleep = 2000
+        if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
+            local pos = GetEntityCoords(PlayerPedId())
+            for k, v in pairs(Config.Locations["stash"]) do
+                if #(pos - v) < 4.5 then
+                    if onDuty then
+                        sleep = 5
+                        if #(pos - v) < 1.5 then
+                            DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Personal stash")
+                            if IsControlJustReleased(0, 38) then
+                                TriggerServerEvent("inventory:server:OpenInventory", "stash", "policestash_"..QBCore.Functions.GetPlayerData().citizenid)
+                                TriggerEvent("inventory:client:SetCurrentStash", "policestash_"..QBCore.Functions.GetPlayerData().citizenid)
+                            end
+                        elseif #(pos - v) < 2.5 then
+                            DrawText3D(v.x, v.y, v.z, "Personal stash")
+                        end
+                    end
+                end
+            end
+        end
+        Wait(sleep)
+    end
+end)
+
+-- Police Bin
+CreateThread(function()
+    Wait(1000)
+    while true do
+        local sleep = 2000
+        if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
+            local pos = GetEntityCoords(PlayerPedId())
             for k, v in pairs(Config.Locations["trash"]) do
                 if #(pos - v) < 2 then
                     sleep = 5
                     if #(pos - v) < 1.0 then
-                        DrawText3D(v.x, v.y, v.z, "~r~E~w~ - Bin")
+                        DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Bin")
                         if IsControlJustReleased(0, 38) then
                             TriggerServerEvent("inventory:server:OpenInventory", "stash", "policetrash", {
                                 maxweight = 4000000,
@@ -521,55 +642,94 @@ CreateThread(function()
                     end
                 end
             end
+        end
+        Wait(sleep)
+    end
+end)
 
-            for k, v in pairs(Config.Locations["vehicle"]) do
-                if #(pos - vector3(v.x, v.y, v.z)) < 7.5 then
+-- Fingerprint
+CreateThread(function()
+    Wait(1000)
+    while true do
+        local sleep = 2000
+        if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
+            local pos = GetEntityCoords(PlayerPedId())
+            for k, v in pairs(Config.Locations["fingerprint"]) do
+                if #(pos - v) < 4.5 then
                     if onDuty then
                         sleep = 5
-                        DrawMarker(2, v.x, v.y, v.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 200, 0, 0, 222, false, false, false, true, false, false, false)
-                        if #(pos - vector3(v.x, v.y, v.z)) < 1.5 then
-                            if IsPedInAnyVehicle(PlayerPedId(), false) then
-                                DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Store vehicle")
-                            else
-                                DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Vehicles")
-                            end
+                        if #(pos - v) < 1.5 then
+                            DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Scan fingerprint")
                             if IsControlJustReleased(0, 38) then
-                                if IsPedInAnyVehicle(PlayerPedId(), false) then
-                                    QBCore.Functions.DeleteVehicle(GetVehiclePedIsIn(PlayerPedId()))
+                                local player, distance = GetClosestPlayer()
+                                if player ~= -1 and distance < 2.5 then
+                                    local playerId = GetPlayerServerId(player)
+                                    TriggerServerEvent("police:server:showFingerprint", playerId)
                                 else
-                                    MenuGarage()
-                                    currentGarage = k
+                                    QBCore.Functions.Notify("No one nearby!", "error")
                                 end
                             end
+                        elseif #(pos - v) < 2.5 then
+                            DrawText3D(v.x, v.y, v.z, "Finger scan")
                         end
                     end
                 end
             end
+        end
+        Wait(sleep)
+    end
+end)
 
-            for k, v in pairs(Config.Locations["impound"]) do
-                if #(pos - vector3(v.x, v.y, v.z)) < 7.5 then
+-- Armory
+CreateThread(function()
+    Wait(1000)
+    while true do
+        local sleep = 2000
+        if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
+            local pos = GetEntityCoords(PlayerPedId())
+            for k, v in pairs(Config.Locations["armory"]) do
+                if #(pos - v) < 4.5 then
                     if onDuty then
                         sleep = 5
-                        DrawMarker(2, v.x, v.y, v.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 200, 0, 0, 222, false, false, false, true, false, false, false)
-                        if #(pos - vector3(v.x, v.y, v.z)) < 1.5 then
-                            if IsPedInAnyVehicle(PlayerPedId(), false) then
-                                DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Impound Vehicle")
-                            else
-                                DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Police Impound")
-                            end
+                        if #(pos - v) < 1.5 then
+                            DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Armory")
                             if IsControlJustReleased(0, 38) then
-                                if IsPedInAnyVehicle(PlayerPedId(), false) then
-                                    QBCore.Functions.DeleteVehicle(GetVehiclePedIsIn(PlayerPedId()))
-                                else
-                                    MenuImpound()
-                                    currentGarage = k
+                                local authorizedItems = {
+                                    label = "Police Armory",
+                                    slots = 30,
+                                    items = {}
+                                }
+                                local index = 1
+                                for _, armoryItem in pairs(Config.Items.items) do
+                                    for i=1, #armoryItem.authorizedJobGrades do
+                                        if armoryItem.authorizedJobGrades[i] == PlayerJob.grade.level then
+                                            authorizedItems.items[index] = armoryItem
+                                            authorizedItems.items[index].slot = index
+                                            index = index + 1
+                                        end
+                                    end
                                 end
+                                SetWeaponSeries()
+                                TriggerServerEvent("inventory:server:OpenInventory", "shop", "police", authorizedItems)
                             end
+                        elseif #(pos - v) < 2.5 then
+                            DrawText3D(v.x, v.y, v.z, "Armory")
                         end
                     end
                 end
             end
+        end
+        Wait(sleep)
+    end
+end)
 
+-- Helicopter
+CreateThread(function()
+    Wait(1000)
+    while true do
+        local sleep = 2000
+        if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
+            local pos = GetEntityCoords(PlayerPedId())
             for k, v in pairs(Config.Locations["helicopter"]) do
                 if #(pos - vector3(v.x, v.y, v.z)) < 7.5 then
                     if onDuty then
@@ -603,73 +763,106 @@ CreateThread(function()
                     end
                 end
             end
+        end
+        Wait(sleep)
+    end
+end)
 
-            for k, v in pairs(Config.Locations["armory"]) do
-                if #(pos - v) < 4.5 then
+-- Police Impound
+CreateThread(function()
+    Wait(1000)
+    local headerDrawn = false
+
+    while true do
+        local sleep = 2000
+        if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
+            local pos = GetEntityCoords(PlayerPedId())
+            for k, v in pairs(Config.Locations["impound"]) do
+                if #(pos - vector3(v.x, v.y, v.z)) < 7.5 then
                     if onDuty then
                         sleep = 5
-                        if #(pos - v) < 1.5 then
-                            DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Armory")
-                            if IsControlJustReleased(0, 38) then
-                                local authorizedItems = {
-                                    label = "Police Armory",
-                                    slots = 30,
-                                    items = {}
-                                }
-                                local index = 1
-                                for _, armoryItem in pairs(Config.Items.items) do
-                                    for i=1, #armoryItem.authorizedJobGrades do
-                                        if armoryItem.authorizedJobGrades[i] == PlayerJob.grade.level then
-                                            authorizedItems.items[index] = armoryItem
-                                            authorizedItems.items[index].slot = index
-                                            index = index + 1
-                                        end
-                                    end
+                        DrawMarker(2, v.x, v.y, v.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 200, 0, 0, 222, false, false, false, true, false, false, false)
+                        if #(pos - vector3(v.x, v.y, v.z)) <= 1.5 then
+                            if IsPedInAnyVehicle(PlayerPedId(), false) then
+                                DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Impound Vehicle")
+                            else
+                                if not headerDrawn then
+                                    headerDrawn = true
+                                    exports['qb-menu']:showHeader({
+                                        {
+                                            header = 'Police Impound',
+                                            params = {
+                                                event = 'police:client:ImpoundMenuHeader',
+                                                args = {
+                                                    currentSelection = k,
+                                                }
+                                            }
+                                        }
+                                    })
                                 end
-                                SetWeaponSeries()
-                                TriggerServerEvent("inventory:server:OpenInventory", "shop", "police", authorizedItems)
+                                -- DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Police Impound")
                             end
-                        elseif #(pos - v) < 2.5 then
-                            DrawText3D(v.x, v.y, v.z, "Armory")
+                            if IsControlJustReleased(0, 38) then
+                                if IsPedInAnyVehicle(PlayerPedId(), false) then
+                                    QBCore.Functions.DeleteVehicle(GetVehiclePedIsIn(PlayerPedId()))
+                                end
+                            end
+                        else
+                            if headerDrawn then
+                                headerDrawn = false
+                                exports['qb-menu']:closeMenu()
+                            end
                         end
                     end
                 end
             end
+        end
+        Wait(sleep)
+    end
+end)
 
-            for k, v in pairs(Config.Locations["stash"]) do
-                if #(pos - v) < 4.5 then
+-- Police Vehicle Garage
+CreateThread(function()
+    Wait(1000)
+    local headerDrawn = false
+    while true do
+        local sleep = 2000
+        if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
+            local pos = GetEntityCoords(PlayerPedId())
+            for k, v in pairs(Config.Locations["vehicle"]) do
+                if #(pos - vector3(v.x, v.y, v.z)) < 7.5 then
                     if onDuty then
                         sleep = 5
-                        if #(pos - v) < 1.5 then
-                            DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Personal stash")
-                            if IsControlJustReleased(0, 38) then
-                                TriggerServerEvent("inventory:server:OpenInventory", "stash", "policestash_"..QBCore.Functions.GetPlayerData().citizenid)
-                                TriggerEvent("inventory:client:SetCurrentStash", "policestash_"..QBCore.Functions.GetPlayerData().citizenid)
-                            end
-                        elseif #(pos - v) < 2.5 then
-                            DrawText3D(v.x, v.y, v.z, "Personal stash")
-                        end
-                    end
-                end
-            end
-
-            for k, v in pairs(Config.Locations["fingerprint"]) do
-                if #(pos - v) < 4.5 then
-                    if onDuty then
-                        sleep = 5
-                        if #(pos - v) < 1.5 then
-                            DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Scan fingerprint")
-                            if IsControlJustReleased(0, 38) then
-                                local player, distance = GetClosestPlayer()
-                                if player ~= -1 and distance < 2.5 then
-                                    local playerId = GetPlayerServerId(player)
-                                    TriggerServerEvent("police:server:showFingerprint", playerId)
-                                else
-                                    QBCore.Functions.Notify("No one nearby!", "error")
+                        DrawMarker(2, v.x, v.y, v.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 200, 0, 0, 222, false, false, false, true, false, false, false)
+                        if #(pos - vector3(v.x, v.y, v.z)) < 1.5 then
+                            if IsPedInAnyVehicle(PlayerPedId(), false) then
+                                DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Store vehicle")
+                            else
+                                if not headerDrawn then
+                                    headerDrawn = true
+                                    exports['qb-menu']:showHeader({
+                                        {
+                                            header = 'Police Garage',
+                                            params = {
+                                                event = 'police:client:VehicleMenuHeader',
+                                                args = {
+                                                    currentSelection = k,
+                                                }
+                                            }
+                                        }
+                                    })
                                 end
                             end
-                        elseif #(pos - v) < 2.5 then
-                            DrawText3D(v.x, v.y, v.z, "Finger scan")
+                            if IsControlJustReleased(0, 38) then
+                                if IsPedInAnyVehicle(PlayerPedId(), false) then
+                                    QBCore.Functions.DeleteVehicle(GetVehiclePedIsIn(PlayerPedId()))
+                                end
+                            end
+                        else
+                            if headerDrawn then
+                                headerDrawn = false
+                                exports['qb-menu']:closeMenu()
+                            end
                         end
                     end
                 end

--- a/client/job.lua
+++ b/client/job.lua
@@ -419,6 +419,39 @@ RegisterNetEvent('police:client:TakeOutVehicle', function(data)
     end
 end)
 
+RegisterNetEvent('police:client:EvidenceStashDrawer', function(data)
+    local currentEvidence = data.currentEvidence
+    local pos = GetEntityCoords(PlayerPedId())
+    local takeLoc = Config.Locations["evidence"][currentEvidence]
+
+    if not takeLoc then return end
+
+    if #(pos - takeLoc) <= 1.0 then
+        local drawer = exports['qb-input']:ShowInput({
+            header = 'Evidence Stash | '.. currentEvidence,
+            submitText = "open",
+            inputs = {
+                {
+                    type = 'number',
+                    isRequired = true,
+                    name = 'slot',
+                    text = 'Slot no. (1,2,3)'
+                }
+            }
+        })
+        if drawer then
+            if not drawer.slot then return end
+            TriggerServerEvent("inventory:server:OpenInventory", "stash", currentEvidence.." | Drawer "..drawer.slot, {
+                maxweight = 4000000,
+                slots = 500,
+            })
+            TriggerEvent("inventory:client:SetCurrentStash", currentEvidence.." | Drawer "..drawer.slot)
+        end
+    else
+        exports['qb-menu']:closeMenu()
+    end
+end)
+
 --[[
     Section: Threads
 
@@ -461,6 +494,8 @@ end)
 -- Stash 1
 CreateThread(function()
     Wait(1000)
+    local headerDrawn = false
+
     while true do
         local sleep = 2000
         if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
@@ -469,119 +504,26 @@ CreateThread(function()
                 if #(pos - v) < 2 then
                     sleep = 5
                     if #(pos - v) < 1.0 then
-                        DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Evidence stash")
-                        if IsControlJustReleased(0, 38) then
-                            local drawer = exports['qb-input']:ShowInput({
-                                header = 'Evidence Stash',
-                                submitText = "open",
-                                inputs = {
-                                    {
-                                        type = 'number',
-                                        isRequired = true,
-                                        name = 'slot',
-                                        text = 'Slot no. (1,2,3)'
+                        if not headerDrawn then
+                            headerDrawn = true
+                            exports['qb-menu']:showHeader({
+                                {
+                                    header = 'Evidence Stash | ' .. k,
+                                    params = {
+                                        event = 'police:client:EvidenceStashDrawer',
+                                        args = {
+                                            currentEvidence = k
+                                        }
                                     }
                                 }
                             })
-                            if drawer then
-                                if not drawer.slot then return end
-                                TriggerServerEvent("inventory:server:OpenInventory", "stash", " 1 | Drawer "..drawer.slot, {
-                                    maxweight = 4000000,
-                                    slots = 500,
-                                })
-                                TriggerEvent("inventory:client:SetCurrentStash", " 1 | Drawer "..drawer.slot)
-                            end
                         end
                     elseif #(pos - v) < 1.5 then
-                        DrawText3D(v.x, v.y, v.z, "Stash 1")
-                    end
-                end
-            end
-        end
-        Wait(sleep)
-    end
-end)
-
--- Stash 2
-CreateThread(function()
-    Wait(1000)
-    while true do
-        local sleep = 2000
-        if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
-            local pos = GetEntityCoords(PlayerPedId())
-            for k, v in pairs(Config.Locations["evidence2"]) do
-                if #(pos - v) < 2 then
-                    sleep = 5
-                    if #(pos - v) < 1.0 then
-                        DrawText3D(v.x, v.y, v.z, "~g~E~w~ - evidence stash")
-                        if IsControlJustReleased(0, 38) then
-                            local drawer = exports['qb-input']:ShowInput({
-                                header = 'Evidence Stash',
-                                submitText = "open",
-                                inputs = {
-                                    {
-                                        type = 'number',
-                                        isRequired = true,
-                                        name = 'slot',
-                                        text = 'Slot no. (1,2,3)'
-                                    }
-                                }
-                            })
-                            if drawer then
-                                if not drawer.slot then return end
-                                TriggerServerEvent("inventory:server:OpenInventory", "stash", " 2 | Drawer "..drawer.slot, {
-                                    maxweight = 4000000,
-                                    slots = 500,
-                                })
-                                TriggerEvent("inventory:client:SetCurrentStash", " 2 | Drawer "..drawer.slot)
-                            end
+                        DrawText3D(v.x, v.y, v.z, "Stash " .. k)
+                        if headerDrawn then
+                            headerDrawn = false
+                            exports['qb-menu']:closeMenu()
                         end
-                    elseif #(pos - v) < 1.5 then
-                        DrawText3D(v.x, v.y, v.z, "Stash 2")
-                    end
-                end
-            end
-        end
-        Wait(sleep)
-    end
-end)
-
--- Stash 3
-CreateThread(function()
-    Wait(1000)
-    while true do
-        local sleep = 2000
-        if LocalPlayer.state.isLoggedIn and PlayerJob.name == "police" then
-            local pos = GetEntityCoords(PlayerPedId())
-            for k, v in pairs(Config.Locations["evidence3"]) do
-                if #(pos - v) < 2 then
-                    sleep = 5
-                    if #(pos - v) < 1.0 then
-                        DrawText3D(v.x, v.y, v.z, "~g~E~w~ - Evidence stash")
-                        if IsControlJustReleased(0, 38) then
-                            local drawer = exports['qb-input']:ShowInput({
-                                header = 'Evidence Stash',
-                                submitText = "open",
-                                inputs = {
-                                    {
-                                        type = 'number',
-                                        isRequired = true,
-                                        name = 'slot',
-                                        text = 'Slot no. (1,2,3)'
-                                    }
-                                }
-                            })
-                            if drawer then
-                                if not drawer.slot then return end
-                                TriggerServerEvent("inventory:server:OpenInventory", "stash", " 3 | Drawer "..drawer.slot, {
-                                    maxweight = 4000000,
-                                    slots = 500,
-                                })
-                                TriggerEvent("inventory:client:SetCurrentStash", " 3 | Drawer "..drawer.slot)
-                            end
-                        end
-                    elseif #(pos - v) < 1.5 then
-                        DrawText3D(v.x, v.y, v.z, "Stash 3")
                     end
                 end
             end

--- a/config.lua
+++ b/config.lua
@@ -40,12 +40,8 @@ Config.Locations = {
    },
    ["evidence"] = {
        [1] = vector3(442.1722, -996.067, 30.689),
-   },
-   ["evidence2"] = {
-       [1] = vector3(451.7031, -973.232, 30.689),
-   },
-   ["evidence3"] = {
-       [1] = vector3(455.1456, -985.462, 30.689),
+       [2] = vector3(451.7031, -973.232, 30.689),
+       [3] = vector3(455.1456, -985.462, 30.689),
    },
    ["stations"] = {
        [1] = {label = "Police Station", coords = vector4(428.23, -984.28, 29.76, 3.5)},
@@ -215,7 +211,7 @@ Config.Items = {
             price = 0,
             amount = 1,
             info = {
-                serie = "",                
+                serie = "",
                 attachments = {
                     {component = "COMPONENT_AT_PI_FLSH", label = "Flashlight"},
                 }
@@ -229,7 +225,7 @@ Config.Items = {
             price = 0,
             amount = 1,
             info = {
-                serie = "",            
+                serie = "",
             },
             type = "weapon",
             slot = 2,
@@ -254,7 +250,7 @@ Config.Items = {
             price = 0,
             amount = 1,
             info = {
-                serie = "",                
+                serie = "",
                 attachments = {
                     {component = "COMPONENT_AT_SCOPE_MACRO_02", label = "1x Scope"},
                     {component = "COMPONENT_AT_AR_FLSH", label = "Flashlight"},


### PR DESCRIPTION
**Describe Pull request**
Kind of a big change. 
- Separated the main job thread into multiple threads, this opens up the future possibility of only running when they come on duty (as they only need to be available for players with the police job). 
- Removed evidence2 and evidence3 config options and squashed it into the evidence config location. 
- Removed DrawText for Impound, Vehicle, and Evidence Draw replaced with qb-menu show header.
- Fixed distance check for impound and vehicle spawning.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
