### PR TITLE
fix: police unable to retrieve vehicle from police impound

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -395,7 +395,7 @@ RegisterNetEvent("police:client:ImpoundMenuHeader", function (data)
     takeDist = vector3(takeDist.x, takeDist.y,  takeDist.z)
     if #(pos - takeDist) <= 1.5 then
         MenuImpound(data.currentSelection)
-        currentGarage = k
+        currentGarage = data.currentSelection
     end
 end)
 


### PR DESCRIPTION
**Describe Pull request**
Fixes an issue where police aren't able to retrieve vehicles from the police impound lot to return to the player.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)  yes
- Does your code fit the style guidelines? [yes/no] yes
- Does your PR fit the contribution guidelines? [yes/no] yes
