### PR TITLE
Vehicle flags are now saved in the database

### DIFF
--- a/newdb.sql
+++ b/newdb.sql
@@ -1,3 +1,3 @@
 ALTER TABLE player_vehicles
-ADD flags VARCHAR(50)
+ADD flags VARCHAR(50),
 ALTER flags SET DEFAULT '';

--- a/newdb.sql
+++ b/newdb.sql
@@ -1,0 +1,3 @@
+ALTER TABLE player_vehicles
+ADD flags VARCHAR(50)
+ALTER flags SET DEFAULT '';


### PR DESCRIPTION
**Describe Pull request**
With this pull request, the vehicle flags are now saved in the database, and they can also be fetched through external resources. I think it should be included, because the old way (by saving in the files) isn't optimal, as they can't be fetched by external resources. Now they are saved even if you restart the server.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes, I have, and it works fine.
- Does your code fit the style guidelines? I guess.
- Does your PR fit the contribution guidelines? I guess.
