### PR TITLE
:bug: fixed: bracket in wrong location causing error

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -137,7 +137,7 @@ QBCore.Commands.Add("grantlicense", Lang:t("commands.license_grant"), {{name = "
             TriggerClientEvent('QBCore:Notify', src, Lang:t("error.error_license_type"), "error")
         end
     else
-        TriggerClientEvent('QBCore:Notify', src, Lang:t("error.rank_license", "error"))
+        TriggerClientEvent('QBCore:Notify', src, Lang:t("error.rank_license"), "error")
     end
 end)
 


### PR DESCRIPTION
**Describe Pull request**
A wrongfully placed bracket "(" caused an error when entering the command /grantlicense as an officer with an insufficient rank.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
