### PR TITLE
fix(client/main): duplicate duty trigger

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -101,16 +101,14 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
 end)
 
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
-    PlayerJob = JobInfo
-    TriggerServerEvent("police:server:UpdateBlips")
-    if JobInfo.name == "police" then
-        if PlayerJob.onduty then
+    if JobInfo.name == "police" and PlayerJob.name ~= "police" then
+        if JobInfo.onduty then
             TriggerServerEvent("QBCore:ToggleDuty")
             onDuty = false
         end
     end
 
-    if (PlayerJob ~= nil) and PlayerJob.name ~= "police" then
+    if JobInfo.name ~= "police" then
         if DutyBlips then
             for k, v in pairs(DutyBlips) do
                 RemoveBlip(v)
@@ -118,6 +116,8 @@ RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
         end
         DutyBlips = {}
     end
+    PlayerJob = JobInfo
+    TriggerServerEvent("police:server:UpdateBlips")
 end)
 
 RegisterNetEvent('police:client:sendBillingMail', function(amount)


### PR DESCRIPTION
**Describe Pull request**
This fixes the issue that you get set off duty whenever you go on duty because the on job update event gets called with the setjobduty function of qb-core since recently

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
