### PR TITLE
fix(blips): duty check causing blip issue

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -137,8 +137,7 @@ RegisterNetEvent('police:client:sendBillingMail', function(amount)
 end)
 
 RegisterNetEvent('police:client:UpdateBlips', function(players)
-    if PlayerJob and (PlayerJob.name == 'police' or PlayerJob.name == 'ambulance') and
-        onDuty then
+    if PlayerJob and (PlayerJob.name == 'police' or PlayerJob.name == 'ambulance') then
         if DutyBlips then
             for k, v in pairs(DutyBlips) do
                 RemoveBlip(v)


### PR DESCRIPTION
Client side duty check caused blips not to work for ambulance job. This duty check is unnecessary anyway since duty is already checked before triggering client event.

**Describe Pull request**
Ambulance job blips wouldn't work. After some investigating I found that this onDuty check within police job was the cause. Because when clocking in as ambulance employee, onDuty becomes true within ambulance job, but not within the police job. 

I made the change, tested it and noticed that the onDuty check was unnecessary because duty status is checked before triggering the client event. 
If your PR is to fix an issue mention that issue here
On duty ambulance employees wouldn't get blips.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? No, fully tested it on my local but it's not fully updated. About 2 weeks old.
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes