### PR TITLE
Remove duplicate command

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -431,26 +431,6 @@ QBCore.Commands.Add("ankletlocation", Lang:t("commands.ankletlocation"), {{name 
     end
 end)
 
-QBCore.Commands.Add("removeanklet", Lang:t("commands.removeanklet"), {{name = "cid", help = Lang:t('info.citizen_id')}}, true,function(source, args)
-    local src = source
-    local Player = QBCore.Functions.GetPlayer(src)
-    if Player.PlayerData.job.name == "police" and Player.PlayerData.job.onduty then
-        if args[1] then
-            local citizenid = args[1]
-            local Target = QBCore.Functions.GetPlayerByCitizenId(citizenid)
-            if Target then
-                if Target.PlayerData.metadata["tracker"] then
-                    TriggerClientEvent("police:client:SendTrackerLocation", Target.PlayerData.source, src)
-                else
-                    TriggerClientEvent('QBCore:Notify', src, Lang:t("error.no_anklet"), 'error')
-                end
-            end
-        end
-    else
-        TriggerClientEvent('QBCore:Notify', src, Lang:t("error.on_duty_police_only"), 'error')
-    end
-end)
-
 QBCore.Commands.Add("takedrivinglicense", Lang:t("commands.drivinglicense"), {}, false, function(source, args)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)


### PR DESCRIPTION
**Describe Pull request**
The /removeanklet and /ankletlocation commands are doing exactly same thing. Just remove the removeanklet command its basically useless at this point. If you want to remove the anklet from someone, just do /anklet again and if the target player already has anklet on, it will be removed then.

**Questions (please complete the following information):**

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]