### PR TITLE
Fix wrong cop amount

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -434,9 +434,9 @@ end)
 -- Toggle Duty in an event.
 RegisterNetEvent('qb-policejob:ToggleDuty', function()
     onDuty = not onDuty
+    TriggerServerEvent("QBCore:ToggleDuty")
     TriggerServerEvent("police:server:UpdateCurrentCops")
     TriggerServerEvent("police:server:UpdateBlips")
-    TriggerServerEvent("QBCore:ToggleDuty")
 end)
 
 RegisterNetEvent('qb-police:client:scanFingerPrint', function()


### PR DESCRIPTION
**Describe Pull request**
The problem is that the UpdateCurrentCops is executed before the ToggleDuty of the player. Thats used to not add up the player to the cop amount.

If your PR is to fix an issue mention that issue here
#https://github.com/qbcore-framework/qb-policejob/issues/266

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
