### PR TITLE
Prevent Civs from pulling out vehicles

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -799,7 +799,7 @@ CreateThread(function()
     garageCombo:onPlayerInOut(function(isPointInside, point)
         if isPointInside then
             inGarage = true
-            if onDuty then
+            if onDuty and PlayerJob.name == 'police' then
                 if IsPedInAnyVehicle(PlayerPedId(), false) then
                     exports['qb-core']:DrawText(Lang:t('info.store_veh'), 'left')
                 else


### PR DESCRIPTION
This hotfix on line 802 prevents civilians or any other job from pulling out a vehicle when they arent clocked in as police.

Funny fix but it works

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
