### PR TITLE
Fix

### DIFF
--- a/client/evidence.lua
+++ b/client/evidence.lua
@@ -217,7 +217,7 @@ CreateThread(function() -- Gunpowder Status when shooting
     while true do
         Wait(1)
         local ped = PlayerPedId()
-        if IsPedShooting(ped) or IsPedDoingDriveby(ped) then
+        if IsPedShooting(ped) then
             local weapon = GetSelectedPedWeapon(ped)
             if not WhitelistedWeapon(weapon) then
                 shotAmount = shotAmount + 1


### PR DESCRIPTION
**Describe Pull request**
The InDriveby native detects if the ped/player is aiming in the car, Removing it fixes the issue of people getting the gunpowder status when people are aiming without shooting whilst in the car

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
