### PR TITLE
fix(client/main): remove duplicate event

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -45,7 +45,6 @@ AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
     PlayerJob = player.job
     onDuty = player.job.onduty
     isHandcuffed = false
-    TriggerServerEvent("QBCore:Server:SetMetaData", "ishandcuffed", false)
     TriggerServerEvent("police:server:SetHandcuffStatus", false)
     TriggerServerEvent("police:server:UpdateBlips")
     TriggerServerEvent("police:server:UpdateCurrentCops")


### PR DESCRIPTION
**Describe Pull request**
This fixes the issue of using an exploitable event and using a duplicate event, because `police:server:SetHandcuffStatus` already sets the metadata so it doesn't need to be done twice

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
