### PR TITLE
Predefine quality for weapons

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Config.CarItems = { -- Default Trunk Items for Police Vehicles
     },
 }
 
-Config.Items = { -- Items to be displayed on Armory
+Config.Items = {
     label = "Police Armory",
     slots = 30,
     items = {
@@ -321,6 +321,7 @@ Config.Items = { -- Items to be displayed on Armory
             amount = 1,
             info = {
                 serie = "",
+                quality = 100,
                 attachments = {
                     {component = "COMPONENT_AT_PI_FLSH", label = "Flashlight"},
                 }
@@ -335,6 +336,7 @@ Config.Items = { -- Items to be displayed on Armory
             amount = 1,
             info = {
                 serie = "",
+                quality = 100,
             },
             type = "weapon",
             slot = 2,
@@ -346,6 +348,7 @@ Config.Items = { -- Items to be displayed on Armory
             amount = 1,
             info = {
                 serie = "",
+                quality = 100,
                 attachments = {
                     {component = "COMPONENT_AT_AR_FLSH", label = "Flashlight"},
                 }
@@ -360,6 +363,7 @@ Config.Items = { -- Items to be displayed on Armory
             amount = 1,
             info = {
                 serie = "",
+                quality = 100,
                 attachments = {
                     {component = "COMPONENT_AT_SCOPE_MACRO_02", label = "1x Scope"},
                     {component = "COMPONENT_AT_AR_FLSH", label = "Flashlight"},
@@ -375,6 +379,7 @@ Config.Items = { -- Items to be displayed on Armory
             amount = 1,
             info = {
                 serie = "",
+                quality = 100,
                 attachments = {
                     {component = "COMPONENT_AT_AR_FLSH", label = "Flashlight"},
                     {component = "COMPONENT_AT_SCOPE_MEDIUM", label = "3x Scope"},

--- a/config.lua
+++ b/config.lua
@@ -219,6 +219,7 @@ Config.Items = {
             amount = 1,
             info = {
                 serie = "",
+                quality = 100,
                 attachments = {
                     {component = "COMPONENT_AT_PI_FLSH", label = "Flashlight"},
                 }
@@ -233,6 +234,7 @@ Config.Items = {
             amount = 1,
             info = {
                 serie = "",
+                quality = 100,
             },
             type = "weapon",
             slot = 2,
@@ -244,6 +246,7 @@ Config.Items = {
             amount = 1,
             info = {
                 serie = "",
+                quality = 100,
                 attachments = {
                     {component = "COMPONENT_AT_AR_FLSH", label = "Flashlight"},
                 }
@@ -258,6 +261,7 @@ Config.Items = {
             amount = 1,
             info = {
                 serie = "",
+                quality = 100,
                 attachments = {
                     {component = "COMPONENT_AT_SCOPE_MACRO_02", label = "1x Scope"},
                     {component = "COMPONENT_AT_AR_FLSH", label = "Flashlight"},
@@ -273,6 +277,7 @@ Config.Items = {
             amount = 1,
             info = {
                 serie = "",
+                quality = 100,
                 attachments = {
                     {component = "COMPONENT_AT_AR_FLSH", label = "Flashlight"},
                     {component = "COMPONENT_AT_SCOPE_MEDIUM", label = "3x Scope"},


### PR DESCRIPTION
While totally intended behavior, not so much favored. qb-policejob itself defines the [`item info`](https://github.com/qbcore-framework/qb-policejob/blob/e3c28385d2a59f02c27aa6cc0537088d2011a0b4/config.lua#L245-L250) in the config. Also making the quality result in nil. Fix for the recent weapon quality bugs and https://github.com/qbcore-framework/qb-weapons/issues/127

Tested and ready to ship.
![alt text](https://cdn.discordapp.com/avatars/166971354678165505/a_fa101c352fa4ce0482da9a730f6bea9f.gif?size=1024 "ChatDisabled")

