### PR TITLE
Fix `GetDutyPlayers` callback

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -539,9 +539,9 @@ QBCore.Functions.CreateCallback('police:GetDutyPlayers', function(_, cb)
     for _, v in pairs(players) do
         if v and v.PlayerData.job.name == "police" and v.PlayerData.job.onduty then
             dutyPlayers[#dutyPlayers+1] = {
-                source = Player.PlayerData.source,
-                label = Player.PlayerData.metadata["callsign"],
-                job = Player.PlayerData.job.name
+                source = v.PlayerData.source,
+                label = v.PlayerData.metadata["callsign"],
+                job = v.PlayerData.job.name
             }
         end
     end


### PR DESCRIPTION
**Describe Pull request**
Fixes a bug introduced by d80d630 where the `GetDutyPlayers` callback uses a non-existent variable.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
