### PR TITLE
Send impounded vehicle correctly

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -968,7 +968,13 @@ function impound()
                 if onDuty then sleep = 5 end
                 if IsPedInAnyVehicle(PlayerPedId(), false) then
                     if IsControlJustReleased(0, 38) then
-                        QBCore.Functions.DeleteVehicle(GetVehiclePedIsIn(PlayerPedId()))
+                        local veh = GetVehiclePedIsIn(PlayerPedId())
+                        local plate = QBCore.Functions.GetPlate(veh)
+                        local bodyDamage = math.ceil(GetVehicleBodyHealth(veh))
+                        local engineDamage = math.ceil(GetVehicleEngineHealth(veh))
+                        local totalFuel = exports['LegacyFuel']:GetFuel(veh)
+                        TriggerServerEvent("police:server:Impound", plate, true, 0, bodyDamage, engineDamage, totalFuel)
+                        QBCore.Functions.DeleteVehicle(veh)
                         break
                     end
                 end


### PR DESCRIPTION
When using the police impound location it is only deleting the vehicle so you need to go to depot to pick up your car. With this change it sends the car to the police impound and the menu can be used to pickup the vehicle.

Fixes : #339 

Questions (please complete the following information):

Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes, tested on multiple servers Does your code fit the style guidelines? Yes
Does your PR fit the contribution guidelines? Yes
