### PR TITLE
put in vehicle with 2 doors

### DIFF
--- a/client/interactions.lua
+++ b/client/interactions.lua
@@ -70,7 +70,7 @@ RegisterNetEvent('police:client:PutInVehicle', function()
     if isHandcuffed or isEscorted then
         local vehicle = QBCore.Functions.GetClosestVehicle()
         if DoesEntityExist(vehicle) then
-			for i = GetVehicleMaxNumberOfPassengers(vehicle), 1, -1 do
+            for i = GetVehicleMaxNumberOfPassengers(vehicle), 0, -1 do
                 if IsVehicleSeatFree(vehicle, i) then
                     isEscorted = false
                     TriggerEvent('hospital:client:isEscorted', isEscorted)
@@ -82,7 +82,7 @@ RegisterNetEvent('police:client:PutInVehicle', function()
                     return
                 end
             end
-		end
+        end
     end
 end)
 


### PR DESCRIPTION
You were not allowed to put in the suspect in car with 2 doors becuase it was looping from 1 (driver side back seat) to the found amount of seats > 2. In a 2 doors car the passenger seat is 0 and the driver seat is -1 so it needs to loop from 0 to find the available seat.

Have you personally loaded this code into an updated qbcore project and checked all it's functionality? No, but community members does Does your code fit the style guidelines? yes
Does your PR fit the contribution guidelines? yes
