### PR TITLE
[UPDATE] Deprecate onDuty variable from qb-policejob

### DIFF
--- a/client/evidence.lua
+++ b/client/evidence.lua
@@ -315,7 +315,7 @@ CreateThread(function()
     while true do
         Wait(10)
         if LocalPlayer.state.isLoggedIn then
-            if PlayerJob.name == 'police' and onDuty then
+            if PlayerJob.name == 'police' and PlayerJob.onduty then
                 if IsPlayerFreeAiming(PlayerId()) and GetSelectedPedWeapon(PlayerPedId()) == `WEAPON_FLASHLIGHT` then
                     if next(Casings) then
                         local pos = GetEntityCoords(PlayerPedId(), true)

--- a/client/heli.lua
+++ b/client/heli.lua
@@ -138,7 +138,7 @@ CreateThread(function()
 	while true do
 		Wait(0)
 		if LocalPlayer.state.isLoggedIn then
-			if PlayerJob.name == 'police' and onDuty then
+			if PlayerJob.name == 'police' and PlayerJob.onduty then
 				if IsPlayerInPolmav() then
 					local lPed = PlayerPedId()
 					local heli = GetVehiclePedIsIn(lPed)

--- a/client/job.lua
+++ b/client/job.lua
@@ -1098,4 +1098,3 @@ CreateThread(function()
         end
     end)
 end)
-

--- a/client/job.lua
+++ b/client/job.lua
@@ -838,9 +838,9 @@ else
         if isPointInside then
             inStash = true
             if PlayerJob.name == 'police' and PlayerJob.onduty then
-            	exports['qb-core']:DrawText(Lang:t('info.stash_enter'), 'left')
-            	stash()
-	    end
+                exports['qb-core']:DrawText(Lang:t('info.stash_enter'), 'left')
+                stash()
+            end
         else
             inStash = false
             exports['qb-core']:HideText()

--- a/client/job.lua
+++ b/client/job.lua
@@ -877,7 +877,7 @@ else
     local fingerprintZones = {}
     for _, v in pairs(Config.Locations["fingerprint"]) do
         fingerprintZones[#fingerprintZones+1] = BoxZone:Create(
-            vector3(vector3(v.x, v.y, v.z)), 2, 1 {
+            vector3(vector3(v.x, v.y, v.z)), 2, 1, {
             name="box_zone",
             debugPoly = false,
             minZ = v.z - 1,

--- a/client/job.lua
+++ b/client/job.lua
@@ -449,7 +449,6 @@ RegisterNetEvent('police:client:EvidenceStashDrawer', function(data)
 end)
 
 RegisterNetEvent('qb-policejob:ToggleDuty', function()
-    onDuty = not onDuty
     TriggerServerEvent("QBCore:ToggleDuty")
     TriggerServerEvent("police:server:UpdateCurrentCops")
     TriggerServerEvent("police:server:UpdateBlips")
@@ -528,7 +527,6 @@ local function dutylistener()
         while dutylisten do
             if PlayerJob.name == "police" then
                 if IsControlJustReleased(0, 38) then
-                    onDuty = not onDuty
                     TriggerServerEvent("police:server:UpdateCurrentCops")
                     TriggerServerEvent("QBCore:ToggleDuty")
                     TriggerServerEvent("police:server:UpdateBlips")
@@ -549,7 +547,7 @@ local function stash()
         while true do
             Wait(0)
             if inStash and PlayerJob.name == "police" then
-                if onDuty then sleep = 5 end
+                if PlayerJob.onduty then sleep = 5 end
                 if IsControlJustReleased(0, 38) then
                     TriggerServerEvent("inventory:server:OpenInventory", "stash", "policestash_"..QBCore.Functions.GetPlayerData().citizenid)
                     TriggerEvent("inventory:client:SetCurrentStash", "policestash_"..QBCore.Functions.GetPlayerData().citizenid)
@@ -568,7 +566,7 @@ local function trash()
         while true do
             Wait(0)
             if inTrash and PlayerJob.name == "police" then
-                if onDuty then sleep = 5 end
+                if PlayerJob.onduty then sleep = 5 end
                 if IsControlJustReleased(0, 38) then
                     TriggerServerEvent("inventory:server:OpenInventory", "stash", "policetrash", {
                         maxweight = 4000000,
@@ -590,7 +588,7 @@ local function fingerprint()
         while true do
             Wait(0)
             if inFingerprint and PlayerJob.name == "police" then
-                if onDuty then sleep = 5 end
+                if PlayerJob.onduty then sleep = 5 end
                 if IsControlJustReleased(0, 38) then
                     TriggerEvent("qb-police:client:scanFingerPrint")
                     break
@@ -608,7 +606,7 @@ local function armoury()
         while true do
             Wait(0)
             if inAmoury and PlayerJob.name == "police" then
-                if onDuty then sleep = 5 end
+                if PlayerJob.onduty then sleep = 5 end
                 if IsControlJustReleased(0, 38) then
                     TriggerEvent("qb-police:client:openArmoury")
                     break
@@ -626,7 +624,7 @@ local function heli()
         while true do
             Wait(0)
             if inHelicopter and PlayerJob.name == "police" then
-                if onDuty then sleep = 5 end
+                if PlayerJob.onduty then sleep = 5 end
                 if IsControlJustReleased(0, 38) then
                     TriggerEvent("qb-police:client:spawnHelicopter")
                     break
@@ -644,7 +642,7 @@ local function impound()
         while true do
             Wait(0)
             if inImpound and PlayerJob.name == "police" then
-                if onDuty then sleep = 5 end
+                if PlayerJob.onduty then sleep = 5 end
                 if IsPedInAnyVehicle(PlayerPedId(), false) then
                     if IsControlJustReleased(0, 38) then
                         QBCore.Functions.DeleteVehicle(GetVehiclePedIsIn(PlayerPedId()))
@@ -664,7 +662,7 @@ local function garage()
         while true do
             Wait(0)
             if inGarage and PlayerJob.name == "police" then
-                if onDuty then sleep = 5 end
+                if PlayerJob.onduty then sleep = 5 end
                 if IsPedInAnyVehicle(PlayerPedId(), false) then
                     if IsControlJustReleased(0, 38) then
                         QBCore.Functions.DeleteVehicle(GetVehiclePedIsIn(PlayerPedId()))
@@ -810,7 +808,7 @@ else
     dutyCombo:onPlayerInOut(function(isPointInside)
         if isPointInside then
             dutylisten = true
-            if not onDuty then
+            if not PlayerJob.onduty then
                 exports['qb-core']:DrawText(Lang:t('info.on_duty'),'left')
                 dutylistener()
             else
@@ -839,11 +837,13 @@ else
     stashCombo:onPlayerInOut(function(isPointInside, _, _)
         if isPointInside then
             inStash = true
-            exports['qb-core']:DrawText(Lang:t('info.stash_enter'), 'left')
-            stash()
+            if PlayerJob.name == 'police' and PlayerJob.onduty then
+            	exports['qb-core']:DrawText(Lang:t('info.stash_enter'), 'left')
+            	stash()
+	    end
         else
-            exports['qb-core']:HideText()
             inStash = false
+            exports['qb-core']:HideText()
         end
     end)
 
@@ -863,7 +863,7 @@ else
     trashCombo:onPlayerInOut(function(isPointInside)
         if isPointInside then
             inTrash = true
-            if onDuty then
+            if PlayerJob.name == 'police' and PlayerJob.onduty then
                 exports['qb-core']:DrawText(Lang:t('info.trash_enter'),'left')
                 trash()
             end
@@ -877,7 +877,7 @@ else
     local fingerprintZones = {}
     for _, v in pairs(Config.Locations["fingerprint"]) do
         fingerprintZones[#fingerprintZones+1] = BoxZone:Create(
-            vector3(vector3(v.x, v.y, v.z)), 2, 1, {
+            vector3(vector3(v.x, v.y, v.z)), 2, 1 {
             name="box_zone",
             debugPoly = false,
             minZ = v.z - 1,
@@ -889,7 +889,7 @@ else
     fingerprintCombo:onPlayerInOut(function(isPointInside)
         if isPointInside then
             inFingerprint = true
-            if onDuty then
+            if PlayerJob.name == 'police' and PlayerJob.onduty then
                 exports['qb-core']:DrawText(Lang:t('info.scan_fingerprint'),'left')
                 fingerprint()
             end
@@ -915,7 +915,7 @@ else
     armouryCombo:onPlayerInOut(function(isPointInside)
         if isPointInside then
             inAmoury = true
-            if onDuty then
+            if PlayerJob.name == 'police' and PlayerJob.onduty then
                 exports['qb-core']:DrawText(Lang:t('info.enter_armory'),'left')
                 armoury()
             end
@@ -943,7 +943,7 @@ CreateThread(function()
     local evidenceCombo = ComboZone:Create(evidenceZones, {name = "evidenceCombo", debugPoly = false})
     evidenceCombo:onPlayerInOut(function(isPointInside)
         if isPointInside then
-            if PlayerJob.name == "police" and onDuty then
+            if PlayerJob.name == "police" and PlayerJob.onduty then
                 local currentEvidence = 0
                 local pos = GetEntityCoords(PlayerPedId())
 
@@ -985,7 +985,7 @@ CreateThread(function()
     helicopterCombo:onPlayerInOut(function(isPointInside)
         if isPointInside then
             inHelicopter = true
-            if onDuty then
+            if PlayerJob.name == 'police' and PlayerJob.onduty then
                 if IsPedInAnyVehicle(PlayerPedId(), false) then
                     exports['qb-core']:HideText()
                     exports['qb-core']:DrawText(Lang:t('info.store_heli'), 'left')
@@ -1018,7 +1018,7 @@ CreateThread(function()
     impoundCombo:onPlayerInOut(function(isPointInside, point)
         if isPointInside then
             inImpound = true
-            if onDuty then
+            if PlayerJob.name == 'police' and PlayerJob.onduty then
                 if IsPedInAnyVehicle(PlayerPedId(), false) then
                     exports['qb-core']:DrawText(Lang:t('info.impound_veh'), 'left')
                     impound()
@@ -1066,7 +1066,7 @@ CreateThread(function()
     garageCombo:onPlayerInOut(function(isPointInside, point)
         if isPointInside then
             inGarage = true
-            if onDuty and PlayerJob.name == 'police' then
+            if PlayerJob.name == 'police' and PlayerJob.onduty then
                 if IsPedInAnyVehicle(PlayerPedId(), false) then
                     exports['qb-core']:DrawText(Lang:t('info.store_veh'), 'left')
 		    garage()

--- a/client/main.lua
+++ b/client/main.lua
@@ -4,7 +4,6 @@ isHandcuffed = false
 cuffType = 1
 isEscorted = false
 PlayerJob = {}
-onDuty = false
 local DutyBlips = {}
 
 -- Functions
@@ -43,7 +42,6 @@ end
 AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
     local player = QBCore.Functions.GetPlayerData()
     PlayerJob = player.job
-    onDuty = player.job.onduty
     isHandcuffed = false
     TriggerServerEvent("police:server:SetHandcuffStatus", false)
     TriggerServerEvent("police:server:UpdateBlips")
@@ -87,7 +85,7 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     TriggerServerEvent("police:server:UpdateCurrentCops")
     isHandcuffed = false
     isEscorted = false
-    onDuty = false
+    PlayerJob = {}
     ClearPedTasks(PlayerPedId())
     DetachEntity(PlayerPedId(), true, false)
     if DutyBlips then
@@ -99,13 +97,6 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
 end)
 
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
-    if JobInfo.name == "police" and PlayerJob.name ~= "police" then
-        if JobInfo.onduty then
-            TriggerServerEvent("QBCore:ToggleDuty")
-            onDuty = false
-        end
-    end
-
     if JobInfo.name ~= "police" then
         if DutyBlips then
             for _, v in pairs(DutyBlips) do
@@ -136,7 +127,7 @@ end)
 
 RegisterNetEvent('police:client:UpdateBlips', function(players)
     if PlayerJob and (PlayerJob.name == 'police' or PlayerJob.name == 'ambulance') and
-        onDuty then
+        PlayerJob.onduty then
         if DutyBlips then
             for _, v in pairs(DutyBlips) do
                 RemoveBlip(v)

--- a/client/main.lua
+++ b/client/main.lua
@@ -96,6 +96,10 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     end
 end)
 
+RegisterNetEvent("QBCore:Client:SetDuty", function(newDuty)
+    PlayerJob.onduty = newDuty
+end)
+
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
     if JobInfo.name ~= "police" then
         if DutyBlips then


### PR DESCRIPTION
**Describe Pull request**
Remove redundant onDuty variable used. Also removed that switching from another job to a police job will automatically clock you out, if clocked in. This doesn't make sense, especially for multijob scripts. If this was something needed, then it should be the default duty in the job shared lua and when the job is set it will automatically set the job duty.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) yes
- Does your code fit the style guidelines? [yes/no] yes
- Does your PR fit the contribution guidelines? [yes/no] yes