### PR TITLE
fix(job): fix duty loop not breaking

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -818,7 +818,7 @@ else
                 dutylistener()
             end
         else
-            inDuty = false
+            dutylisten = false
             exports['qb-core']:HideText()
         end
     end)


### PR DESCRIPTION
**Describe Pull request**
Fixes the issue reported in #387. 
When entering the duty boxzone a loop would be triggered. When exiting the zone, the loop should be stopped, but it was not allowing the user to press E at any time after leaving the zone and toggling duty. 

This PR ensures the loop is stopped when leaving the boxzone.

If your PR is to fix an issue mention that issue here
https://github.com/qbcore-framework/qb-policejob/issues/387

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
