### PR TITLE
fix(client/job): Fix inconsistent vehicle deletions when using /depot

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -359,6 +359,10 @@ RegisterNetEvent('police:client:ImpoundVehicle', function(fullImpound, price)
             }, function() -- Play When Done
                 local plate = QBCore.Functions.GetPlate(vehicle)
                 TriggerServerEvent("police:server:Impound", plate, fullImpound, price, bodyDamage, engineDamage, totalFuel)
+                while NetworkGetEntityOwner(vehicle) ~= 128 do  -- Ensure we have entity ownership to prevent inconsistent vehicle deletion
+                    NetworkRequestControlOfEntity(vehicle)
+                    Wait(100)
+                end
                 QBCore.Functions.DeleteVehicle(vehicle)
                 TriggerEvent('QBCore:Notify', Lang:t('success.impounded'), 'success')
                 ClearPedTasks(ped)


### PR DESCRIPTION
**Describe Pull request**
Sometimes with using the `/depot` command, the vehicle would not be deleted. This was being caused by the player calling the command not having ownership of the entity. This PR ensures entity ownership prior to deleting the vehicle.

If your PR is to fix an issue mention that issue here
Fixes #418

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
