### PR TITLE
Nerf OP Thermals: Blocks heat signatures through walls

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -77,6 +77,10 @@ AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
         end
         DutyBlips = {}
     end
+    
+    if Config.BlockWallThermals then
+        SeethroughSetMaxThickness(0.25) -- block thermals from seeing through walls; default is 10000.0
+    end
 end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()

--- a/config.lua
+++ b/config.lua
@@ -8,6 +8,8 @@ Config.Objects = {
     ["light"] = {model = `prop_worklight_03b`, freeze = true},
 }
 
+Config.BlockWallThermals = true -- true/false; lowers thermal cam intensity to stop penetration through walls or tunnels
+
 Config.MaxSpikes = 5
 
 Config.HandCuffItem = 'handcuffs'


### PR DESCRIPTION
**Describe Pull request**
This allows a config flag to disable the default thermal strength in the PD heli. By default, this value is set to 10000.0 which allows you to see through up to 10000.0 units of material. Seeing as some people may prefer this traditionally, I've simply added it as a config option. The native only needs to be set once per session so I am executing it when the player loads. There has been no adverse effect during my testing and production use.

I've included a video showing me flying with the different strengths. Notice the peds under the terrace at the FIB building/tunnel and the peds inside the hospital.

https://medal.tv/games/requested/clips/PObwrjTz_yV1X/JnoTn5Ljbd0i?invite=cr-MSxrbGwsMzIzNTY3NjYs

This PR uses the final value of 0.25. You can see how it looks if you notice the pilot in the heli.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
