### PR TITLE
Custom Polyzone Data in Config

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -117,7 +117,7 @@ function TakeOutImpound(vehicle)
             QBCore.Functions.TriggerCallback('qb-garage:server:GetVehicleProperties', function(properties)
                 QBCore.Functions.SetVehicleProperties(veh, properties)
                 SetVehicleNumberPlateText(veh, vehicle.plate)
-		SetVehicleDirtLevel(veh, 0.0)
+                SetVehicleDirtLevel(veh, 0.0)
                 SetEntityHeading(veh, coords.w)
                 exports['LegacyFuel']:SetFuel(veh, vehicle.fuel)
                 doCarDamage(veh, vehicle)
@@ -685,34 +685,34 @@ if Config.UseTarget then
     CreateThread(function()
         -- Toggle Duty
         for k, v in pairs(Config.Locations["duty"]) do
-            exports['qb-target']:AddBoxZone("PoliceDuty_"..k, vector3(v.x, v.y, v.z), 1, 1, {
+            exports['qb-target']:AddBoxZone("PoliceDuty_"..k, vector3(v.coords.x, v.coords.y, v.coords.z), v.length, v.width, {
                 name = "PoliceDuty_"..k,
-                heading = 11,
+                heading = v.heading,
                 debugPoly = false,
-                minZ = v.z - 1,
-                maxZ = v.z + 1,
-            }, {
+                minZ = v.coords.z - 1,
+                maxZ = v.coords.z + 1,
+            },{
                 options = {
                     {
                         type = "client",
                         event = "qb-policejob:ToggleDuty",
                         icon = "fas fa-sign-in-alt",
-                        label = "Sign In",
+                        label = "Sign In/Out",
                         job = "police",
                     },
                 },
-                distance = 1.5
+                distance = v.distance
             })
         end
 
         -- Personal Stash
         for k, v in pairs(Config.Locations["stash"]) do
-            exports['qb-target']:AddBoxZone("PoliceStash_"..k, vector3(v.x, v.y, v.z), 1.5, 1.5, {
+            exports['qb-target']:AddBoxZone("PoliceStash_"..k, vector3(v.coords.x, v.coords.y, v.coords.z), v.length, v.width, {
                 name = "PoliceStash_"..k,
-                heading = 11,
+                heading = v.heading,
                 debugPoly = false,
-                minZ = v.z - 1,
-                maxZ = v.z + 1,
+                minZ = v.coords.z - 1,
+                maxZ = v.coords.z + 1,
             }, {
                 options = {
                     {
@@ -723,18 +723,18 @@ if Config.UseTarget then
                         job = "police",
                     },
                 },
-                distance = 1.5
+                distance = v.distance
             })
         end
 
         -- Police Trash
         for k, v in pairs(Config.Locations["trash"]) do
-            exports['qb-target']:AddBoxZone("PoliceTrash_"..k, vector3(v.x, v.y, v.z), 1, 1.75, {
+            exports['qb-target']:AddBoxZone("PoliceTrash_"..k, vector3(v.coords.x, v.coords.y, v.coords.z), v.length, v.width, {
                 name = "PoliceTrash_"..k,
-                heading = 11,
+                heading = v.heading,
                 debugPoly = false,
-                minZ = v.z - 1,
-                maxZ = v.z + 1,
+                minZ = v.coords.z - 1,
+                maxZ = v.coords.z + 1,
             }, {
                 options = {
                     {
@@ -745,18 +745,18 @@ if Config.UseTarget then
                         job = "police",
                     },
                 },
-                distance = 1.5
+                distance = v.distance
             })
         end
 
         -- Fingerprint
         for k, v in pairs(Config.Locations["fingerprint"]) do
-            exports['qb-target']:AddBoxZone("PoliceFingerprint_"..k, vector3(v.x, v.y, v.z), 2, 1, {
+            exports['qb-target']:AddBoxZone("PoliceFingerprint_"..k, vector3(v.coords.x, v.coords.y, v.coords.z), v.length, v.width, {
                 name = "PoliceFingerprint_"..k,
-                heading = 11,
+                heading = v.heading,
                 debugPoly = false,
-                minZ = v.z - 1,
-                maxZ = v.z + 1,
+                minZ = v.coords.z - 1,
+                maxZ = v.coords.z + 1,
             }, {
                 options = {
                     {
@@ -767,29 +767,29 @@ if Config.UseTarget then
                         job = "police",
                     },
                 },
-                distance = 1.5
+                distance = v.distance
             })
         end
 
         -- Armoury
         for k, v in pairs(Config.Locations["armory"]) do
-            exports['qb-target']:AddBoxZone("PoliceArmory_"..k, vector3(v.x, v.y, v.z), 5, 1, {
+            exports['qb-target']:AddBoxZone("PoliceArmory_"..k, vector3(v.coords.x, v.coords.y, v.coords.z), v.length, v.width, {
                 name = "PoliceArmory_"..k,
-                heading = 11,
+                heading = v.heading,
                 debugPoly = false,
-                minZ = v.z - 1,
-                maxZ = v.z + 1,
+                minZ = v.coords.z - 1,
+                maxZ = v.coords.z + 1,
             }, {
                 options = {
                     {
                         type = "client",
                         event = "qb-police:client:openArmoury",
-                        icon = "fas fa-swords",
+                        icon = "fas fa-dungeon",
                         label = "Open Armory",
                         job = "police",
                     },
                 },
-                distance = 1.5
+                distance = v.distance
             })
         end
 
@@ -801,11 +801,11 @@ else
     local dutyZones = {}
     for _, v in pairs(Config.Locations["duty"]) do
         dutyZones[#dutyZones+1] = BoxZone:Create(
-            vector3(vector3(v.x, v.y, v.z)), 1.75, 1, {
+            vector3(vector3(v.coords.x, v.coords.y, v.coords.z)), v.length, v.width, {
             name="box_zone",
             debugPoly = false,
-            minZ = v.z - 1,
-            maxZ = v.z + 1,
+            minZ = v.coords.z - 1,
+            maxZ = v.coords.z + 1,
         })
     end
 
@@ -830,11 +830,11 @@ else
     local stashZones = {}
     for _, v in pairs(Config.Locations["stash"]) do
         stashZones[#stashZones+1] = BoxZone:Create(
-            vector3(vector3(v.x, v.y, v.z)), 1.5, 1.5, {
+            vector3(vector3(v.coords.x, v.coords.y, v.coords.z)), v.length, v.width, {
             name="box_zone",
             debugPoly = false,
-            minZ = v.z - 1,
-            maxZ = v.z + 1,
+            minZ = v.coords.z - 1,
+            maxZ = v.coords.z + 1,
         })
     end
 
@@ -856,11 +856,11 @@ else
     local trashZones = {}
     for _, v in pairs(Config.Locations["trash"]) do
         trashZones[#trashZones+1] = BoxZone:Create(
-            vector3(vector3(v.x, v.y, v.z)), 1, 1.75, {
+            vector3(vector3(v.coords.x, v.coords.y, v.coords.z)), v.length, v.width, {
             name="box_zone",
             debugPoly = false,
-            minZ = v.z - 1,
-            maxZ = v.z + 1,
+            minZ = v.coords.z - 1,
+            maxZ = v.coords.z + 1,
         })
     end
 
@@ -882,11 +882,11 @@ else
     local fingerprintZones = {}
     for _, v in pairs(Config.Locations["fingerprint"]) do
         fingerprintZones[#fingerprintZones+1] = BoxZone:Create(
-            vector3(vector3(v.x, v.y, v.z)), 2, 1, {
+            vector3(vector3(v.coords.x, v.coords.y, v.coords.z)), v.length, v.width, {
             name="box_zone",
             debugPoly = false,
-            minZ = v.z - 1,
-            maxZ = v.z + 1,
+            minZ = v.coords.z - 1,
+            maxZ = v.coords.z + 1,
         })
     end
 
@@ -908,11 +908,11 @@ else
     local armouryZones = {}
     for _, v in pairs(Config.Locations["armory"]) do
         armouryZones[#armouryZones+1] = BoxZone:Create(
-            vector3(vector3(v.x, v.y, v.z)), 5, 1, {
+            vector3(vector3(v.coords.x, v.coords.y, v.coords.z)), v.length, v.width, {
             name="box_zone",
             debugPoly = false,
-            minZ = v.z - 1,
-            maxZ = v.z + 1,
+            minZ = v.coords.z - 1,
+            maxZ = v.coords.z + 1,
         })
     end
 

--- a/config.lua
+++ b/config.lua
@@ -17,8 +17,9 @@ Config.LicenseRank = 2
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true'
 Config.Locations = {
     ["duty"] = {
-        [1] = vector3(440.085, -974.924, 30.689),
-        [2] = vector3(-449.811, 6012.909, 31.815),
+        [1] = {coords = vector3(440.085, -974.924, 30.689), length = 1, width = 2.45, heading = 11, distance = 2.5}, --mrpd
+        [2] = {coords = vector3(-449.811, 6012.909, 31.815), length = 1, width = 2.45, heading = 49.48, distance = 2.5}, --paleto
+        [3] = {coords = vector3(1851.58, 3691.67, 34.26), length = 1, width = 2.45, heading = 38.97, distance = 2.5}, --sandy
     },
     ["vehicle"] = {
         [1] = vector4(448.159, -1017.41, 28.562, 90.654),
@@ -26,7 +27,7 @@ Config.Locations = {
         [3] = vector4(-455.39, 6002.02, 31.34, 87.93),
     },
     ["stash"] = {
-        [1] = vector3(453.075, -980.124, 30.889),
+        [1] = {coords = vector3(453.075, -980.124, 30.889), length = 1.5, width = 2.5, heading = 264.99, distance = 1.5}, --mrpd
     },
     ["impound"] = {
         [1] = vector3(436.68, -1007.42, 27.32),
@@ -37,13 +38,13 @@ Config.Locations = {
         [2] = vector4(-475.43, 5988.353, 31.716, 31.34),
     },
     ["armory"] = {
-        [1] = vector3(462.23, -981.12, 30.68),
+        [1] = {coords = vector3(462.23, -981.12, 30.68), length = 5, width = 1, heading = 11, distance = 1.5}, --mrpd
     },
     ["trash"] = {
-        [1] = vector3(439.0907, -976.746, 30.776),
+        [1] = {coords = vector3(439.0907, -976.746, 30.776), length = 1, width = 1.75, heading = 11, distance = 1.5},
     },
     ["fingerprint"] = {
-        [1] = vector3(460.9667, -989.180, 24.92),
+        [1] = {coords = vector3(460.9667, -989.180, 24.92), length = 2, width = 1, heading = 11, distance = 1.5},
     },
     ["evidence"] = {
         [1] = vector3(442.1722, -996.067, 30.689),
@@ -51,9 +52,12 @@ Config.Locations = {
         [3] = vector3(455.1456, -985.462, 30.689),
     },
     ["stations"] = {
-        [1] = {label = "Police Station", coords = vector4(428.23, -984.28, 29.76, 3.5)},
+        [1] = {label = "Police Station", coords = vector4(428.23, -984.28, 29.76, 3.5)}, -- MRPD
         [2] = {label = "Prison", coords = vector4(1845.903, 2585.873, 45.672, 272.249)},
-        [3] = {label = "Police Station Paleto", coords = vector4(-451.55, 6014.25, 31.716, 223.81)},
+        [3] = {label = "Police Station", coords = vector4(-451.55, 6014.25, 31.716, 223.81)}, -- Paleto
+        [4] = {label = "Police Station", coords = vector4(364.75, -1587.68, 29.29, 223.81)}, -- Davis
+        [5] = {label = "Police Station", coords = vector4(1854.09, 3686.66, 34.26, 193.67)}, -- Sandy
+        [6] = {label = "Police Station", coords = vector4(-1085.08, -810.74, 19.34, 211.39)}, -- Vespucci
     },
 }
 


### PR DESCRIPTION
**Describe Pull request**
This pull request will allow users to add custom polyzone data for the necessary polyzones from the config,lua. It will allow for an easier time when setting up policejob polyzones across the map.  It also adds more PD blips with their names commented. I have implemented this into my own qb-core project and have tested it with no issues.

If your PR is to fix an issue mention that issue here
[#287](https://github.com/qbcore-framework/qb-policejob/issues/287)

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
