### PR TITLE
spikestrip fix

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1081,8 +1081,22 @@ RegisterNetEvent('police:server:SetTracker', function(targetId)
     end
 end)
 
-RegisterNetEvent('police:server:SyncSpikes', function(table)
-    TriggerClientEvent('police:client:SyncSpikes', -1, table)
+QBCore.Functions.CreateUseableItem('spikestrip', function(src)
+    TriggerClientEvent("police:client:usespikes", src)
+end)
+
+RegisterNetEvent('police:server:removespikes', function()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    Player.Functions.RemoveItem('spikestrip', 1)
+end)
+
+RegisterNetEvent("police:server:pickupspikes", function()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if Player.PlayerData.job.name == 'police' then 
+        Player.Functions.AddItem('spikestrip', 1)
+    end
 end)
 
 -- Threads


### PR DESCRIPTION
Fix for issue : https://github.com/qbcore-framework/qb-policejob/issues/333
- you can always pick up the spike strip
- other officers can also pick up the spike strips

- Following code needs to be added to qb-core/shared/items.lua
`
['spikestrip'] 				     = {['name'] = 'spikestrip',					['label'] = 'Spikestrip', 				['weight'] = 100, 		['type'] = 'item', 		['image'] = 'spikestrip.png', 			['unique'] = false, 	['useable'] = true, 	['shouldClose'] = true,	   ['combinable'] = nil,   ['description'] = 'Might be useful when someone is driving recklessly'},`


