### PR TITLE
Toggle Duty FIX

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -532,8 +532,8 @@ local function dutylistener()
         while dutylisten do
             if PlayerJob.name == "police" then
                 if IsControlJustReleased(0, 38) then
-                    TriggerServerEvent("police:server:UpdateCurrentCops")
                     TriggerServerEvent("QBCore:ToggleDuty")
+                    TriggerServerEvent("police:server:UpdateCurrentCops")
                     TriggerServerEvent("police:server:UpdateBlips")
                     dutylisten = false
                     break

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-PoliceJob'
-version '1.2.1'
+version '1.2.2'
 
 shared_scripts {
     'config.lua',


### PR DESCRIPTION
QBCore:ToggleDuty was called after police:server:UpdateCurrentCops

RegisterNetEvent for 'police:SetCopCount' would return wrong value.

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? No
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
