### PR TITLE
Fix heading for helicopter spawn

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -494,7 +494,7 @@ RegisterNetEvent('qb-police:client:spawnHelicopter', function(k)
         QBCore.Functions.DeleteVehicle(GetVehiclePedIsIn(PlayerPedId()))
     else
         local coords = GetEntityCoords(PlayerPedId())
-        for k, v in pairs(Config.Locations["helicopter"]) do
+        for _, v in pairs(Config.Locations["helicopter"]) do
             if #(vector3(v.x, v.y, v.z) - coords) <= 5 then
                 coords = v
             end

--- a/client/job.lua
+++ b/client/job.lua
@@ -489,7 +489,7 @@ RegisterNetEvent('qb-police:client:openArmoury', function()
     TriggerServerEvent("inventory:server:OpenInventory", "shop", "police", authorizedItems)
 end)
 
-RegisterNetEvent('qb-police:client:spawnHelicopter', function(k)
+RegisterNetEvent('qb-police:client:spawnHelicopter', function()
     if IsPedInAnyVehicle(PlayerPedId(), false) then
         QBCore.Functions.DeleteVehicle(GetVehiclePedIsIn(PlayerPedId()))
     else

--- a/client/job.lua
+++ b/client/job.lua
@@ -493,8 +493,12 @@ RegisterNetEvent('qb-police:client:spawnHelicopter', function(k)
     if IsPedInAnyVehicle(PlayerPedId(), false) then
         QBCore.Functions.DeleteVehicle(GetVehiclePedIsIn(PlayerPedId()))
     else
-        local coords = Config.Locations["helicopter"][k]
-        if not coords then coords = GetEntityCoords(PlayerPedId()) end
+        local coords = GetEntityCoords(PlayerPedId())
+        for k, v in pairs(Config.Locations["helicopter"]) do
+            if #(vector3(v.x, v.y, v.z) - coords) <= 5 then
+                coords = v
+            end
+        end
         QBCore.Functions.TriggerCallback('QBCore:Server:SpawnVehicle', function(netId)
             local veh = NetToVeh(netId)
             SetVehicleLivery(veh , 0)


### PR DESCRIPTION
**Describe Pull request**
Since the ID isn't sent to this event, checks for the closest helicopter spawn to set the correct heading from the config's vector4 value. This prevents the helicopter from randomly setting a heading. 

**Questions:**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
