### PR TITLE
Add a notification error when no objects spawned

### DIFF
--- a/client/objects.lua
+++ b/client/objects.lua
@@ -156,7 +156,9 @@ end)
 
 RegisterNetEvent('police:client:deleteObject', function()
     local objectId, dist = GetClosestPoliceObject()
-    if dist < 5.0 then
+    if objectId == nil then
+        QBCore.Functions.Notify(Lang:t("error.no_object"), "error")
+    elseif dist < 5.0 then
         QBCore.Functions.Progressbar("remove_object", Lang:t('progressbar.remove_object'), 2500, false, true, {
             disableMovement = true,
             disableCarMovement = true,
@@ -173,13 +175,19 @@ RegisterNetEvent('police:client:deleteObject', function()
             StopAnimTask(PlayerPedId(), "weapons@first_person@aim_rng@generic@projectile@thermal_charge@", "plant_floor", 1.0)
             QBCore.Functions.Notify(Lang:t("error.canceled"), "error")
         end)
+    else
+        QBCore.Functions.Notify(Lang:t("error.far_away"), "error")
     end
 end)
 
 RegisterNetEvent('police:client:removeObject', function(objectId)
-    NetworkRequestControlOfEntity(ObjectList[objectId].object)
-    DeleteObject(ObjectList[objectId].object)
-    ObjectList[objectId] = nil
+    if ObjectList[objectId] == nil then
+        QBCore.Functions.Notify(Lang:t("error.does_no_exist"), "error")
+    else
+        NetworkRequestControlOfEntity(ObjectList[objectId].object)
+        DeleteObject(ObjectList[objectId].object)
+        ObjectList[objectId] = nil
+    end
 end)
 
 RegisterNetEvent('police:client:spawnObject', function(objectId, type, player)

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -26,7 +26,10 @@ local Translations = {
         no_driver_license = 'No drivers license',
         not_cuffed_dead = 'Civilian isn\'t cuffed or dead',
         fine_yourself = 'You Cannot Fine Yourself',
-        not_online = "This person is not online"
+        not_online = "This person is not online",
+        no_object = "No nearby objects to delete.",
+        far_away = "The object is too far away.",
+        does_no_exist = "Object does not exist"
     },
     success = {
         uncuffed = 'You have been uncuffed',

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -26,7 +26,10 @@ local Translations = {
         no_driver_license = 'Pas de permis de conduire',
         not_cuffed_dead = 'Le civil n\'est pas menotté ou mort.',
         fine_yourself = '???',
-        not_online = "???"
+        not_online = "???",
+        no_object = "Aucun objet à supprimer à proximité.",
+        far_away = "L'objet est trop loin.",
+        does_no_exist = "Objet inexistant"
     },
     success = {
         uncuffed = 'Vous avez été démenotté!',


### PR DESCRIPTION
**Describe Pull request**
The purpose of this pullrequest is to correct the reported bug concerning the fact that when a player presses delete an object in his radial menu when no objects exist, to display a notification to him so that he knows what is happening and avoid causing an error on the client console side

If your PR is to fix an issue mention that issue here - [BUG] Remove Object doesn't exists #477

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
