### PR TITLE
adds export (client and server sided) for GetCops

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -222,3 +222,16 @@ CreateThread(function()
         EndTextCommandSetBlipName(blip)
     end
 end)
+
+local function getCops()
+    local amount = 0
+    local recieved = false
+    QBCore.Functions.TriggerCallback('police:GetCops', function(data)
+        amount = data
+        recieved = true
+    end)
+    repeat Wait(1) until recieved
+    return amount
+end
+
+exports('GetCops', getCops)

--- a/server/main.lua
+++ b/server/main.lua
@@ -39,6 +39,7 @@ local function GetCurrentCops()
     return amount
 end
 
+exports('GetCops', GetCurrentCops)
 -- Callbacks
 
 QBCore.Functions.CreateCallback('police:GetDutyPlayers', function(_, cb)


### PR DESCRIPTION
**Describe Pull request**
added export for GetCops which returns the number of cops that are clocked in.

example: ( client and server side work the same way)
```lua
  if not exports['qb-policejob']:GetCops() >= Config.MinCops then 
       print('Not Enough Cops')
       return
 end
```
  
  Or the latter 
  
 ```lua
    if exports['qb-policejob']:GetCops() >= Config.MinCops then
        print('enough cops')
    end
 ```

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
