### PR TITLE
feat(security): block unsafe HTML tags in police alerts to prevent XSS

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -145,8 +145,21 @@ RegisterNetEvent('qb-policejob:server:evidence', function(currentEvidence)
     })
 end)
 
+local unsafeTags = {
+    "<script", "</script", "<img", "<iframe", "<object", "<embed", "<svg",
+    "<link", "<style", "<meta", "<html", "<body", "<video", "<audio", "<a"
+}
+
 RegisterNetEvent('police:server:policeAlert', function(text)
     local src = source
+
+    local lowerText = string.lower(text or "")
+    for _, tag in pairs(unsafeTags) do
+        if string.find(lowerText, tag) then
+            return 
+        end
+    end
+
     local ped = GetPlayerPed(src)
     local coords = GetEntityCoords(ped)
     local players = QBCore.Functions.GetQBPlayers()


### PR DESCRIPTION
Added a validation step in the `police:server:policeAlert` event to check for potentially dangerous HTML tags (e.g., <script>, <img>, <iframe>, etc.) in the `text` input. This mitigates the risk of cross-site scripting (XSS) attacks from user-submitted content.

**Describe Pull request**
This pull request adds a security validation layer to the `police:server:policeAlert` event, ensuring that any user-submitted `text` does not contain dangerous HTML tags that could be used in XSS attacks. The code scans the input for known malicious tags (e.g., `<script>`, `<img>`, etc.) and blocks the execution if any are found.  
This is important for preventing malicious behavior that could compromise the user interface or negatively impact other players.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
